### PR TITLE
Add Meshtastic backup tool and build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # MeshBack
-test
+
+Utility to backup and restore Meshtastic device configuration and build
+standalone executables for multiple platforms.
+
+## Building executables
+
+Install dependencies and run the build script:
+
+```bash
+pip install meshtastic pyinstaller
+./build.sh
+```
+
+The resulting binaries will be placed under `dist/linux` and
+`dist/windows` (the latter requires `wine`).
+
+## Usage
+
+Once built, run the executable with:
+
+```bash
+./meshback backup /dev/ttyUSB0 config.bin
+./meshback restore /dev/ttyUSB0 config.bin
+```
+
+Replace the serial port and file paths as needed.

--- a/backup_restore.py
+++ b/backup_restore.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Utility to backup and restore Meshtastic device configuration.
+
+This module exposes a small CLI that talks to a Meshtastic device via
+`meshtastic.serial_interface.SerialInterface` and serializes the
+configuration to a binary file.  It is intentionally minimal so it can
+be bundled with PyInstaller for distribution as a standalone executable
+on multiple platforms.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from meshtastic.serial_interface import SerialInterface
+from meshtastic.protobuf import config_pb2
+
+
+def backup(device_port: str, output_file: Path) -> None:
+    """Read configuration from *device_port* and write it to *output_file*."""
+    iface = SerialInterface(device_port)
+    try:
+        config = iface.getConfig()
+        with output_file.open("wb") as fh:
+            fh.write(config.SerializeToString())
+    finally:
+        iface.close()
+
+
+def restore(device_port: str, input_file: Path) -> None:
+    """Write configuration from *input_file* to *device_port*."""
+    data = input_file.read_bytes()
+    config = config_pb2.Config()
+    config.ParseFromString(data)
+
+    iface = SerialInterface(device_port)
+    try:
+        iface.writeConfig(config)
+    finally:
+        iface.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Backup or restore a Meshtastic device")
+    parser.add_argument("action", choices=["backup", "restore"], help="Operation to perform")
+    parser.add_argument("port", help="Serial port of the device, e.g. /dev/ttyUSB0 or COM3")
+    parser.add_argument("file", type=Path, help="File to read from or write to")
+
+    args = parser.parse_args()
+
+    if args.action == "backup":
+        backup(args.port, args.file)
+    else:
+        restore(args.port, args.file)
+
+
+if __name__ == "__main__":
+    main()

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Build standalone executables for Linux and Windows using PyInstaller.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP="backup_restore.py"
+DIST_DIR="$SCRIPT_DIR/dist"
+
+# Ensure dependencies exist
+if ! command -v pyinstaller >/dev/null 2>&1; then
+  echo "pyinstaller is required. Install with: pip install pyinstaller" >&2
+  exit 1
+fi
+
+mkdir -p "$DIST_DIR"
+
+# Build native executable
+pyinstaller --onefile "$SCRIPT_DIR/$APP" \
+  --distpath "$DIST_DIR/linux" \
+  --workpath "$SCRIPT_DIR/build/linux" \
+  --name meshback
+
+# Build Windows executable via wine if available
+if command -v wine >/dev/null 2>&1; then
+  wine pyinstaller --onefile "$SCRIPT_DIR/$APP" \
+    --distpath "$DIST_DIR/windows" \
+    --workpath "$SCRIPT_DIR/build/windows" \
+    --name meshback
+else
+  echo "wine not found; skipping Windows build" >&2
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+meshtastic
+pyinstaller


### PR DESCRIPTION
## Summary
- add `backup_restore.py` with CLI for Meshtastic device backup/restore
- add `build.sh` for building Linux and Windows executables using PyInstaller
- document build and usage in README

## Testing
- `python -m py_compile backup_restore.py`
- `bash -n build.sh`
- `bash build.sh` *(fails: pyinstaller is required)*

------
https://chatgpt.com/codex/tasks/task_e_68907db71b508323bca648275429a3e9