### PR TITLE
Install patchelf for cross-compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ standalone executables for each platform.
 Run the provided script on a Linux host. It sets up a Python virtual
 environment, builds the native binary with PyInstaller and cross-compiles a
 Windows `.exe` via Nuitka using the mingw-w64 toolchain—no Windows Python
-download required:
+download required. The script installs `python3-venv`, `mingw-w64`, and
+`patchelf` (needed by Nuitka on Linux) before building:
 
 ```bash
 ./start_compile.sh

--- a/start_compile.sh
+++ b/start_compile.sh
@@ -7,7 +7,7 @@ set -e
 # Install system dependencies
 sudo apt-get update
 
-sudo apt-get install -y python3-venv mingw-w64
+sudo apt-get install -y python3-venv mingw-w64 patchelf
 
 # Create and activate virtual environment
 


### PR DESCRIPTION
## Summary
- ensure patchelf is installed when building Windows executable with Nuitka
- document patchelf requirement in build instructions

## Testing
- `./start_compile.sh`


------
https://chatgpt.com/codex/tasks/task_e_68945bbb22a88323b8af2a2d0c8f1a45