### PR TITLE
Fix Nuitka command options

### DIFF
--- a/start_compile.sh
+++ b/start_compile.sh
@@ -28,8 +28,6 @@ python -m nuitka \
   --output-dir=dist \
   --output-filename=meshback.exe \
   --mingw64 \
-  --target-os=Windows \
-  --target-arch=x86_64 \
   meshback.py
 
 deactivate


### PR DESCRIPTION
## Summary
- remove deprecated --target-os and --target-arch options from Nuitka invocation in start_compile.sh
- ensure cross-compilation step uses supported Nuitka flags when building Windows executable

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfbd8dd4848323ae1f013b6545b2be